### PR TITLE
Slide

### DIFF
--- a/apps/hongcha/components/ImageCard.tsx
+++ b/apps/hongcha/components/ImageCard.tsx
@@ -32,6 +32,7 @@ const ImageCard = ({ title, posterUrl, id }: ImageCardProps) => {
       <li
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        className="h-full"
         style={isMouseEnter ? { transform: 'scale(1.1)', margin: '0 20px' } : {}}
       >
         <ImageLoader src={posterUrl} width="200" />

--- a/apps/hongcha/components/ImageLoader.tsx
+++ b/apps/hongcha/components/ImageLoader.tsx
@@ -1,6 +1,6 @@
 import useIntersectionObserver from 'hook/useIntersectionObserver';
-import { useEffect, useRef } from 'react';
-
+import { useEffect, useRef, useState } from 'react';
+// TODO:오류 시 재시도 버튼 추가해보기
 interface ImageLoaderType {
   src: string;
   width?: string;
@@ -16,15 +16,29 @@ const ioOptions = {
 const ImageLoader = ({ src, width, height, alt = '' }: ImageLoaderType) => {
   const imgRef = useRef<HTMLImageElement>(null);
   const { entries } = useIntersectionObserver(imgRef, ioOptions);
-
+  const [status, setStatus] = useState<'loading' | 'error' | 'success'>('loading');
   useEffect(() => {
     const isVisible = entries[0]?.isIntersecting;
     if (isVisible) {
+      setStatus('loading');
+      imgRef.current!.onload = () => {
+        setStatus('success');
+      };
+      imgRef.current!.onerror = () => {
+        setStatus('error');
+      };
+
       imgRef.current!.src = src;
     }
   }, [src, entries]);
 
-  return <img ref={imgRef} width={width} height={height} alt={alt} />;
+  return (
+    <div className="w-full h-full">
+      {status === 'loading' && <div className="bg-slate-200 animate-pulse h-full" />}
+      {status === 'error' && <div className=" bg-white h-full">오류 관리자에게 문의하세요</div>}
+      <img ref={imgRef} width={width} height={height} alt={alt} />
+    </div>
+  );
 };
 
 export default ImageLoader;

--- a/apps/hongcha/components/MovieList.tsx
+++ b/apps/hongcha/components/MovieList.tsx
@@ -1,11 +1,50 @@
 import TopRatedResult from 'models/MovieInfoClass';
 import ImageCard from 'components/ImageCard';
+import { useRef, useState, useEffect } from 'react';
 
-const MovieList = ({ results }: { results: TopRatedResult[] }) => (
-  <ul className="flex flex-nowrap  bg-black w-full h-1/2 p-3 overflow-hidden">
-    {results.map(({ id, title, posterUrl }) => (
-      <ImageCard id={id} key={id} title={title} posterUrl={posterUrl} />
-    ))}
-  </ul>
-);
+interface CarouselProps {
+  results: TopRatedResult[];
+  callApi: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const MovieList = ({ results, callApi }: CarouselProps) => {
+  const [index, setIndex] = useState(0);
+  const $ul = useRef<HTMLUListElement>(null);
+  // const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    if (!$ul.current) return;
+    $ul.current.style.transform = `translateX(-${100 * index}%)`;
+  }, [index]);
+
+  const handlePrevPage = () => {
+    const newPage = index - 1;
+    if (newPage === -1) return;
+    setIndex(newPage);
+  };
+
+  const handleNextPage = () => {
+    const newPage = index + 1;
+    if (results.length === newPage * 4) {
+      callApi((prev) => prev + 1);
+    }
+    setIndex(newPage);
+  };
+  return (
+    <div className="bg-black w-full overflow-hidden relative">
+      <button className="bg-white absolute top-0 h-full z-10" onClick={handlePrevPage}>
+        prev
+      </button>
+      <ul ref={$ul} className="flex flex-nowrap transition-transform duration-300">
+        {results.map(({ id, title, posterUrl }) => (
+          <ImageCard id={id} key={id} title={title} posterUrl={posterUrl} />
+        ))}
+      </ul>
+
+      <button className="bg-white absolute h-full top-0 right-0 z-10" onClick={handleNextPage}>
+        next
+      </button>
+    </div>
+  );
+};
 export default MovieList;

--- a/apps/hongcha/components/TopRated.tsx
+++ b/apps/hongcha/components/TopRated.tsx
@@ -1,36 +1,30 @@
 import MovieList from './MovieList';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTopRated } from 'queries/useTopRated';
+import TopRatedResult from 'models/MovieInfoClass';
 
 const TopRated = () => {
-  // TODO: 페이지네이션 관련 처리는 임시 / 추후 캐로셀에서 관리
   const [pageNum, setPageNum] = useState(1);
+  const [items, setItems] = useState<TopRatedResult[]>([]);
 
-  const handlePrevPage = () => {
-    const prevPage = pageNum - 1;
-    if (prevPage <= 0) return;
-    setPageNum((prev) => prev - 1);
-  };
+  const {
+    isFetching,
+    isLoading,
+    data: { results },
+    error,
+  } = useTopRated(pageNum);
 
-  const handleNextPage = () => {
-    const nextPage = pageNum + 1;
-    if (nextPage > totalPages) return;
-    setPageNum((prev) => prev + 1);
-  };
-
-  const { isLoading, results, totalPages, error } = useTopRated(pageNum);
+  useEffect(() => {
+    if (!isFetching && results) {
+      setItems((prev) => [...prev, ...results]);
+    }
+  }, [isFetching]);
 
   if (isLoading) return <div>로딩중</div>;
   if (error) throw error;
 
-  return (
-    <>
-      <MovieList results={results} />
-      <button onClick={handlePrevPage}>이전 페이지</button>
-      <button onClick={handleNextPage}>다음 페이지</button>
-    </>
-  );
+  return <MovieList results={items} callApi={setPageNum} />;
 };
 
 export default TopRated;

--- a/apps/hongcha/components/TopRated.tsx
+++ b/apps/hongcha/components/TopRated.tsx
@@ -20,11 +20,15 @@ const TopRated = () => {
       setItems((prev) => [...prev, ...results]);
     }
   }, [isFetching]);
-
-  if (isLoading) return <div>로딩중</div>;
+  if (isLoading) return <div className="bg-red-600 text-white">리액트 쿼리 로딩중</div>;
   if (error) throw error;
 
-  return <MovieList results={items} callApi={setPageNum} />;
+  return (
+    <div>
+      {isFetching && <div className="bg-blue-600 text-white">리액트 쿼리 중간 로딩중</div>}
+      <MovieList results={items} callApi={setPageNum} />
+    </div>
+  );
 };
 
 export default TopRated;

--- a/apps/hongcha/queries/useTopRated.ts
+++ b/apps/hongcha/queries/useTopRated.ts
@@ -1,22 +1,23 @@
 import MovieInfoClass from 'models/MovieInfoClass';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { getTopRatedList } from 'apis/getTopRatedList';
 import { TMDBQueryResponseType } from 'types/responseTypes';
 
 export const useTopRated = (pageNum: number) => {
-  const {
-    isError,
-    isLoading,
-    error,
-    data: { results = [], totalPages = 0 } = {},
-  } = useQuery<TMDBQueryResponseType, Error, { results: MovieInfoClass[]; totalPages: number }>({
+  const query = useQuery<TMDBQueryResponseType, Error, { results: MovieInfoClass[]; totalPages: number }>({
     queryKey: ['topRated', pageNum],
     queryFn: () => getTopRatedList(pageNum),
     select: (data) => ({
       results: data.results.map((result) => new MovieInfoClass(result)),
       totalPages: data.totalPages,
     }),
+    placeholderData: keepPreviousData,
   });
-
-  return { isError, isLoading, results, totalPages, error };
+  return {
+    ...query,
+    data: {
+      results: query.data?.results ?? [],
+      totalPages: query.data?.totalPages ?? 0,
+    },
+  };
 };


### PR DESCRIPTION
## PR의 종류 (해당되는 항목 모두 체크)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## PR전 체크리스트

- [x] I have performed a self-review of my code
- [x] Semantic하지 않은 변수명이 있는지 확인 했나요?
- [ ] 콘솔 로그, 미사용 코드 및 주석을 다 제거했나요?

## PR 설명
### 1. 이미지 슬라이드 개발
<img width="782" alt="image" src="https://github.com/user-attachments/assets/34e59d55-4a03-4804-86f2-43ee82772e47" />

#### 개발 시 고민했던 점과 어려웠던 점
1. 라이브러리 vs 직접 구현
- 케이스 바이 케이스라고 하지만 일단 처음 생각했던 부분은 무한 캐로셀을 만들고 싶어 라이브러리를 이용하려고 했지만, 기능을 축소시키고 처음부터 컴포넌트를 만드는게 좋을것 같아서 직접 구현하였습니다.
2. 새로운 이미지를 서버에서 받아올 때 화면이 깜빡하는 현상
- 리액트 쿼리의 placeholderData: keepPreviousData로 해결했습니다.
- 하지만 기존 useEffect가 동작하지 않았고 원하는 대로 동작하지 않았습니다.
 ```typescript
useEffect(() => {
     if (isSuccess) {
       setItems((prev) => [...prev, ...results]);
     }
   }, [isSuccess])
```

그래서 isPlaceholderData를 통해 지금 새로운 이미지를 불러오는 경우 isPlaceholderData로
이전 데이터를 유지하는지 확인하는 작업을 진행했습니다.

```typescript
if (isPlaceholderData) {
      setItems((prev) => [...prev, ...results]);
    }
  }, [isPlaceholderData]);
```
그래서 해결방법으로 

```typescript
useEffect(() => {
    if (!isFetching && results) {
      setItems((prev) => [...prev, ...results]);
    }
  }, [isFetching]);
```
을 적용했고 원하는대로 작동하는것을 확인했습니다.


### 2. 이미지 로더 컴포넌트에 스켈레톤 ui추가
```ts
useEffect(() => {
    const isVisible = entries[0]?.isIntersecting;
    if (isVisible) {
      setStatus('loading');
      imgRef.current!.onload = () => {
        setStatus('success');
      };
      imgRef.current!.onerror = () => {
        setStatus('error');
      };

      imgRef.current!.src = src;
    }
  }, [src, entries]);

if(status === 'loading') return <div/>
if(status === 'error') return <div>에러!</div>
return <img ...이미지 정보 코드/>
```
하지만 이렇게 했을 경우 status 기본값이 loading에서
값이 변하지 않고 useEffect 내부 로직이 실행이 되지 않았습니다.

제가 만든 로직은 imgRef를 통해 이미지를 감시하면서 이를 통해
이미지 src를 로드하고 있었는데 조건부 렌더링을 통해서
imgRef가 null로 들어오기 때문에 코드가 실행이 되지 않았던 것입니다.

그래서 코드를
```ts
<div className="w-full h-full">
  {status === 'loading' && <div className="bg-slate-200 animate-pulse h-full" />}
  {status === 'error' && <div className=" bg-white h-full">오류 관리자에게 문의하세요</div>}
  <img ref={imgRef} width={width} height={height} alt={alt} />
</div>
```
로 수정하니 원하는 대로 잘 동작했습니다.

#### 제한점
- 로딩이 리액트쿼리가 불러오는 로딩, 이미지 로드 로딩
이렇게 두개가 있기 때문에 리액트 쿼리가 실행될 때 
만들 로딩 ui를 따로 구분지어야 할 것 같습니다.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._
